### PR TITLE
Added stream_video_dynamic_range and video_dynamic_range

### DIFF
--- a/varken/structures.py
+++ b/varken/structures.py
@@ -400,6 +400,7 @@ class TautulliStream(NamedTuple):
     stream_video_codec: str = None
     stream_video_codec_level: str = None
     stream_video_decision: str = None
+    stream_video_dynamic_range: str = None
     stream_video_framerate: str = None
     stream_video_full_resolution: str = None
     stream_video_height: str = None
@@ -459,6 +460,7 @@ class TautulliStream(NamedTuple):
     video_codec: str = None
     video_codec_level: str = None
     video_decision: str = None
+    video_dynamic_range: str = None
     video_frame_rate: str = None
     video_framerate: str = None
     video_full_resolution: str = None


### PR DESCRIPTION
I ran into an issue with the historical tautulli importer with these fields missing.

```
TypeError has occurred : __new__() got an unexpected keyword argument 'stream_video_dynamic_range' while creating TautulliStream structure
TypeError has occurred : __new__() got an unexpected keyword argument 'video_dynamic_range' while creating TautulliStream structure
```

Adding these fields to the TautulliStream class fixed it for me.
