### PR TITLE
docker-compose: use 1.8 influxdb tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   influxdb:
     hostname: influxdb
     container_name: influxdb
-    image: influxdb
+    image: influxdb:1.8
     networks:
       - internal
     volumes:


### PR DESCRIPTION
Because `latest` now is running on v2, which does not work with varken (yet)