### PR TITLE
update Docker-compose with influxdb v1.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   influxdb:
     hostname: influxdb
     container_name: influxdb
-    image: influxdb
+    image: influxdb:1.8.10
     networks:
       - internal
     volumes:


### PR DESCRIPTION
Needed for the latest compatibility with influxdb, , not compatible with version 2.0+