### PR TITLE
Fix Sonarr & Radarr V3 API /queue endpoint

### DIFF
--- a/varken/structures.py
+++ b/varken/structures.py
@@ -247,6 +247,8 @@ class SonarrQueue(NamedTuple):
     trackedDownloadState: str = None
     trackedDownloadStatus: str = None
     seriesId: int = None
+    errorMessage: str = None
+    outputPath: str = None
 
 
 # Radarr
@@ -308,6 +310,10 @@ class RadarrQueue(NamedTuple):
     title: str = None
     trackedDownloadState: str = None
     trackedDownloadStatus: str = None
+    timeleft: str = None
+    estimatedCompletionTime: str = None
+    errorMessage: str = None
+    outputPath: str = None
 
 
 # Sickchill


### PR DESCRIPTION
The Sonarr & Radarr V3 API `/queue` endpoints return a few keys which don't currently exist in `structures.py`.

I've added the keys so the structs but am not doing anything with them beyond that.  
This PR simply stops Varken failing when the query response includes unexpected keys.