### PR TITLE
Update Sonarr & Lidarr Structs to match latest API changes

### DIFF
--- a/varken/structures.py
+++ b/varken/structures.py
@@ -606,6 +606,7 @@ class LidarrQueue(NamedTuple):
     outputPath: str = None
     downloadForced: bool = None
     id: int = None
+    estimatedCompletionTime: str = None
 
 
 class LidarrAlbum(NamedTuple):

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -255,6 +255,7 @@ class SonarrEpisode(NamedTuple):
     sceneEpisodeNumber: int = None
     sceneSeasonNumber: int = None
     series: SonarrTVShow = None
+    tvdbId: int = None
 
 
 class SonarrQueue(NamedTuple):


### PR DESCRIPTION
Resolves the following errors:

`2022-03-07 22:31:27 : ERROR : sonarr : TypeError has occurred : <lambda>() got an unexpected keyword argument 'tvdbId' while creating SonarrEpisode structure for show. Data attempted is: `
By adding tvdbId type int in SonarrEpisode Struct

`2022-03-07 22:54:11 : ERROR : lidarr : TypeError has occurred : <lambda>() got an unexpected keyword argument 'estimatedCompletionTime' while creating LidarrQueue structure for show.`
By adding estimatedCompletionTime type string in LidarrQueue Struct