### PR TITLE
Add missing fields to get rid of  errors about new fields

### DIFF
--- a/varken/structures.py
+++ b/varken/structures.py
@@ -226,6 +226,7 @@ class SonarrTVShow(NamedTuple):
     monitored: bool = None
     nextAiring: str = None
     network: str = None
+    originalLanguage: dict = None
     overview: str = None
     path: str = None
     previousAiring: str = None

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -255,6 +255,7 @@ class SonarrEpisode(NamedTuple):
     airDateUtc: str = None
     episodeFileId: int = None
     episodeNumber: int = None
+    finaleType: str = None
     grabbed: bool = None
     hasFile: bool = None
     id: int = None

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -222,8 +222,10 @@ class SonarrTVShow(NamedTuple):
     id: int = None
     images: list = None
     imdbId: str = None
+    lastAired: str = None
     languageProfileId: int = None
     monitored: bool = None
+    monitorNewItems: str = None
     nextAiring: str = None
     network: str = None
     originalLanguage: dict = None
@@ -354,8 +356,11 @@ class RadarrMovie(NamedTuple):
 
 # Radarr Queue
 class RadarrQueue(NamedTuple):
+    added: str = None
     customFormats: list = None
+    customFormatScore: int = None
     downloadClient: str = None
+    downloadClientHasPostImportCategory: bool = None
     downloadId: str = None
     id: int = None
     indexer: str = None

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -274,8 +274,13 @@ class SonarrEpisode(NamedTuple):
 
 
 class SonarrQueue(NamedTuple):
+    added: str = None
+    customFormats: list = None
+    customFormatScore: int = None
     downloadClient: str = None
+    downloadClientHasPostImportCategory: bool = None
     downloadId: str = None
+    episodeHasFile: bool = None
     episodeId: int = None
     id: int = None
     indexer: str = None
@@ -283,6 +288,7 @@ class SonarrQueue(NamedTuple):
     languages: list = None
     protocol: str = None
     quality: dict = None
+    seasonNumber: int = None
     size: float = None
     sizeleft: float = None
     status: str = None

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -280,6 +280,7 @@ class SonarrQueue(NamedTuple):
     id: int = None
     indexer: str = None
     language: dict = None
+    languages: list = None
     protocol: str = None
     quality: dict = None
     size: float = None

--- a/varken/structures.py
+++ b/varken/structures.py
@@ -322,11 +322,13 @@ class RadarrMovie(NamedTuple):
     physicalRelease: str = None
     qualityProfileId: int = None
     ratings: dict = None
+    rootFolderPath: str = None
     runtime: int = None
     secondaryYear: int = None
     secondaryYearSourceId: int = None
     sizeOnDisk: float = None
     sortTitle: str = None
+    statistics: dict = None
     status: str = None
     studio: str = None
     tags: list = None


### PR DESCRIPTION
This resolves the errors that are present in this issue: https://github.com/Boerderij/Varken/issues/252

Namely the ones such as:
```
RadarrMovie.new() got an unexpected keyword argument 'rootFolderPath' while creating RadarrMovie structure
```
there are quite a few, but I think I got all of them.  This probably isn't exhaustive, but so far I no longer have any errors showing in my logs.   This should only work with v4 sonarr / v5 radarr, but may work with older versions, I don't know.  Enjoy.