### PR TITLE
Bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.5-alpine
+FROM python:3.12.2-alpine
 
 ENV DEBUG="True" \
     DATA_FOLDER="/config" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@
 # pip3 install -r requirements.txt
 #---------------------------------------------------------
 requests==2.31.0
-geoip2==2.9.0
-influxdb==5.2.0
-schedule==1.1.0
-distro==1.4.0
-urllib3==1.26.10
+geoip2==4.8.0
+influxdb==5.3.1
+schedule==1.2.1
+distro==1.9.0
+urllib3==2.2.1


### PR DESCRIPTION
Bump python/alpine base to latest 3.12.2 alpine 3.19, and bump requirements to latest versions.  Tested in my own kubernetes environment to work.   This solves every issue pointed out by Trivvy as a vulnerability